### PR TITLE
Only highlight  {it,describe}.only, not its arguments

### DIFF
--- a/lib/rules/no-only.js
+++ b/lib/rules/no-only.js
@@ -17,6 +17,7 @@ module.exports = {
           if (['describe', 'it'].includes(callee.object.name) && callee.property.name === 'only') {
             context.report({
               node,
+              loc: { start: callee.object.loc.start, end: callee.property.loc.end },
               message: `Unexpected ${callee.object.name}.only`,
             });
           }

--- a/tests/lib/rules/no-only.js
+++ b/tests/lib/rules/no-only.js
@@ -19,6 +19,8 @@ ruleTester.run('no-only', rule, {
         type: 'CallExpression',
         line: 1,
         column: 1,
+        endLine: 1,
+        endColumn: 14,
       }],
     },
     {
@@ -28,6 +30,8 @@ ruleTester.run('no-only', rule, {
         type: 'CallExpression',
         line: 1,
         column: 1,
+        endLine: 1,
+        endColumn: 8,
       }],
     },
     {
@@ -37,6 +41,8 @@ ruleTester.run('no-only', rule, {
         type: 'CallExpression',
         line: 1,
         column: 22,
+        endLine: 1,
+        endColumn: 29,
       }],
     },
     {
@@ -47,12 +53,16 @@ ruleTester.run('no-only', rule, {
           type: 'CallExpression',
           line: 1,
           column: 1,
+          endLine: 1,
+          endColumn: 14,
         },
         {
           message: 'Unexpected it.only',
           type: 'CallExpression',
           line: 1,
           column: 27,
+          endLine: 1,
+          endColumn: 34,
         },
       ],
     },


### PR DESCRIPTION
Changes the location in the error reporting to only highlight the `describe.only` / `it.only` object and function name, but not their arguments.

Behavior before:
- When developing a test and focusing it with `it.only`, the whole test code is underlined in red, making it difficult to get type check and linting information for the code under development.

Behavior after:
- When developing a test and focusing it with `it.only`, only the first part of the test (`it.only`) is underlined in red, making it easy to get type check and linting information for the code under development.
